### PR TITLE
Fix outdated rspec config and syntax

### DIFF
--- a/certifi.gemspec
+++ b/certifi.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-core"
   spec.add_development_dependency "rspec-expectations"

--- a/spec/certifi_spec.rb
+++ b/spec/certifi_spec.rb
@@ -1,5 +1,6 @@
 require_relative 'spec_helper'
 require_relative '../lib/certifi'
+require "net/http"
 
 describe Certifi do
   describe ".where" do

--- a/spec/certifi_spec.rb
+++ b/spec/certifi_spec.rb
@@ -5,7 +5,7 @@ require "net/http"
 describe Certifi do
   describe ".where" do
     it "should return the path to the cacert.pem" do
-      expect(File.exist?(Certifi.where)).to be_true
+      expect(File.exist?(Certifi.where)).to be true
     end
 
     it "should verify the cert" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,5 +8,5 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-  config.mock_with :none
+  config.mock_with :nothing
 end


### PR DESCRIPTION
Hello, this is a great gem! I want to use it, but I have some concerns about it.

Certifi's other language distribution (e.g. python) seems well-maintained, but the Ruby version is not. For example, python's last release was 2022-12-07, and ruby's last release was 2018-01-18.

So, I want you to update the ruby distribution certificates from mkcert.org, but first, the current codebase is outdated.

Therefore, I was doing below things...

* remove the bundler's version constraint
* update outdated RSpec configure and syntax

If you want to add CI with GitHub Actions, Sure! I will add workflows. But it will come large diff, so I couldn't it in the first step.